### PR TITLE
Clear frame when disconnecting

### DIFF
--- a/Assets/Nanover/Grpc/Trajectory/TrajectorySession.cs
+++ b/Assets/Nanover/Grpc/Trajectory/TrajectorySession.cs
@@ -110,6 +110,8 @@ namespace Nanover.Grpc.Trajectory
             frameStream?.Dispose();
             frameStream = null;
 
+            trajectorySnapshot.Clear();
+
             await Task.CompletedTask;
         }
 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -831,7 +831,7 @@ PlayerSettings:
   platformArchitecture: {}
   scriptingBackend:
     Android: 1
-    Standalone: 1
+    Standalone: 0
   il2cppCompilerConfiguration: {}
   il2cppCodeGeneration: {}
   il2cppStacktraceInformation: {}


### PR DESCRIPTION
Stops rendering atoms before removing selections, which was leading to solvent flashing before you as you disconnect.