### PR TITLE
Add an offset to the radial menus

### DIFF
--- a/Assets/NanoverImd/NanoverImd Scene.unity
+++ b/Assets/NanoverImd/NanoverImd Scene.unity
@@ -10108,6 +10108,18 @@ PrefabInstance:
       value: -76.60445
       objectReference: {fileID: 0}
     - target: {fileID: 3963654245958493611, guid: 11d9c1728005b9147a8e3a1b6856e431, type: 3}
+      propertyPath: offset.x
+      value: -0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 3963654245958493611, guid: 11d9c1728005b9147a8e3a1b6856e431, type: 3}
+      propertyPath: offset.y
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 3963654245958493611, guid: 11d9c1728005b9147a8e3a1b6856e431, type: 3}
+      propertyPath: offset.z
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3963654245958493611, guid: 11d9c1728005b9147a8e3a1b6856e431, type: 3}
       propertyPath: controllers
       value: 
       objectReference: {fileID: 2074532958}
@@ -15417,6 +15429,18 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 431384315}
+    - target: {fileID: 783323445283192389, guid: 58cdccc6469da4f4b9db76cacd78c500, type: 3}
+      propertyPath: offset.x
+      value: -0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 783323445283192389, guid: 58cdccc6469da4f4b9db76cacd78c500, type: 3}
+      propertyPath: offset.y
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 783323445283192389, guid: 58cdccc6469da4f4b9db76cacd78c500, type: 3}
+      propertyPath: offset.z
+      value: 0.03
+      objectReference: {fileID: 0}
     - target: {fileID: 783323445283192389, guid: 58cdccc6469da4f4b9db76cacd78c500, type: 3}
       propertyPath: controllers
       value: 

--- a/Assets/NanoverImd/UI/PopupUserInterfaceManager.cs
+++ b/Assets/NanoverImd/UI/PopupUserInterfaceManager.cs
@@ -64,6 +64,9 @@ namespace NanoverImd.UI
             openMenu.Released += CloseMenu;
         }
 
+        [SerializeField]
+        private Vector3 offset;
+
         private void ShowMenu()
         {
             if (!controllers.WouldBecomeCurrentMode(mode))
@@ -72,7 +75,7 @@ namespace NanoverImd.UI
             GotoScene(menuPrefab);
             
             SceneUI.transform.position = SceneUI.GetComponent<PhysicalCanvasInput>()
-                                                .Controller.transform.position;
+                                                .Controller.transform.position + offset;
             SceneUI.transform.rotation =
                 Quaternion.LookRotation(SceneUI.transform.position - Camera.main.transform.position,
                                         Vector3.up);


### PR DESCRIPTION
current radial menus appear not really centered around the user controller, so the distance from the controller to each of the buttons is not equal, and the top button label is covered by the controller.

this update adds a (custom) offset. Now the menus are visually centered, and all movements should feel more comfortable.