### PR TITLE
Update keyboard layout with additional  ':'  and  '/' characters

### DIFF
--- a/Assets/NanoverImd/UI/Keyboard.cs
+++ b/Assets/NanoverImd/UI/Keyboard.cs
@@ -31,8 +31,8 @@ namespace NanoverImd.UI
         {
             "1234567890",
             "QWERTYUIOP",
-            "ASDFGHJKL",
-            "ZXCVBNM."
+            "ASDFGHJKL:",
+            "ZXCVBNM./"
         };
 
         private void Start()


### PR DESCRIPTION
Previously missing characters ‘:’ and ‘/’ have now been added to the keyboard layout — ‘:’ on the third row and ‘/’ on the fourth row — to support users in manually connecting to the WebSocket server by typing in VR