### PR TITLE
fix: deserialize particle.colors into Unity Color arrays

### DIFF
--- a/Assets/Nanover/Frame/Frame.cs
+++ b/Assets/Nanover/Frame/Frame.cs
@@ -17,6 +17,7 @@ namespace Nanover.Frame
         public const string ParticleTypeArrayKey = "particle.types";
         public const string ParticleNameArrayKey = "particle.names";
         public const string ParticleResidueArrayKey = "particle.residues";
+        public const string ParticleColorArrayKey = "particle.colors";
         public const string ParticleCountValueKey = "particle.count";
 
         public const string ResidueNameArrayKey = "residue.names";

--- a/Assets/Nanover/Network/FrameConverter.cs
+++ b/Assets/Nanover/Network/FrameConverter.cs
@@ -96,15 +96,17 @@ namespace Nanover.Network.Frame
 
         public static Color[] BytesToColorArray(byte[] bytes)
         {
-            var colors = new Color[bytes.Length / sizeof(float) / 4];
+            var colors = new Color[bytes.Length / 4];
 
             for (int i = 0; i < colors.Length; ++i)
-                colors[i] = new Color(
-                    BitConverter.ToSingle(bytes, (i * 4 + 0) * sizeof(float)),
-                    BitConverter.ToSingle(bytes, (i * 4 + 1) * sizeof(float)),
-                    BitConverter.ToSingle(bytes, (i * 4 + 2) * sizeof(float)),
-                    BitConverter.ToSingle(bytes, (i * 4 + 3) * sizeof(float))
+            {
+                colors[i] = new Color32(
+                    bytes[i * 4 + 0],
+                    bytes[i * 4 + 1],
+                    bytes[i * 4 + 2],
+                    bytes[i * 4 + 3]
                 );
+            }
 
             return colors;
         }

--- a/Assets/Nanover/Network/FrameConverter.cs
+++ b/Assets/Nanover/Network/FrameConverter.cs
@@ -49,6 +49,7 @@ namespace Nanover.Network.Frame
                 [FrameData.ParticlePositionArrayKey] = (value) => Converters.BytesToVector3Array((byte[])value),
                 [FrameData.ParticleElementArrayKey] = (value) => Converters.BytesToElementArray((byte[])value),
                 [FrameData.ParticleResidueArrayKey] = (value) => Converters.BytesToUInt32((byte[])value),
+                [FrameData.ParticleColorArrayKey] = (value) => Converters.BytesToColorArray((byte[])value),
                 [FrameData.ResidueChainArrayKey] = (value) => Converters.BytesToUInt32((byte[])value),
 
                 [FrameData.ParticleNameArrayKey] = (value) => ((object[])value).Cast<string>().ToArray(),
@@ -91,6 +92,21 @@ namespace Nanover.Network.Frame
                 );
 
             return vec3;
+        }
+
+        public static Color[] BytesToColorArray(byte[] bytes)
+        {
+            var colors = new Color[bytes.Length / sizeof(float) / 4];
+
+            for (int i = 0; i < colors.Length; ++i)
+                colors[i] = new Color(
+                    BitConverter.ToSingle(bytes, (i * 4 + 0) * sizeof(float)),
+                    BitConverter.ToSingle(bytes, (i * 4 + 1) * sizeof(float)),
+                    BitConverter.ToSingle(bytes, (i * 4 + 2) * sizeof(float)),
+                    BitConverter.ToSingle(bytes, (i * 4 + 3) * sizeof(float))
+                );
+
+            return colors;
         }
 
         public static Element[] BytesToElementArray(byte[] bytes)


### PR DESCRIPTION
Frames received from a NanoVer server can contain `particle.colors` as packed float32 RGBA bytes. Unlike particle positions and other standard frame arrays, the Unity client did not deserialize this field because `FrameConverter` had no converter registered for `particle.colors`, so the network value remained a `byte[]` instead of becoming a `UnityEngine.Color[]`

As a result, visualisation graphs requesting `particle.colors` could not consume server-provided per-particle colors.

I tested the fix using a NanoVer Python server that publishes one RGBA color per particle. Server-provided `particle.colors` values are now correctly rendered by the Unity client.