### PR TITLE
Transform fixes + box fixes

### DIFF
--- a/Assets/Nanover/Network/Multiplayer/MultiplayerResource.cs
+++ b/Assets/Nanover/Network/Multiplayer/MultiplayerResource.cs
@@ -36,7 +36,9 @@ namespace Nanover.Network.Multiplayer
             this.session = session;
             ResourceKey = key;
             LockState = MultiplayerResourceLockState.Unlocked;
+            session.SharedStateDictionaryCleared += () => Reset(default);
             session.SharedStateDictionaryKeyUpdated += SharedStateDictionaryKeyUpdated;
+            session.SharedStateDictionaryKeyRemoved += (key) => SharedStateDictionaryKeyUpdated(key, null);
             this.objectToValue = objectToValue;
             this.valueToObject = valueToObject;
             CopyRemoteValueToLocal();
@@ -220,6 +222,7 @@ namespace Nanover.Network.Multiplayer
         public void Reset(TValue value)
         {
             this.value = value;
+            sentUpdateIndex = -1;
             localValuePending = false;
             ValueChanged?.Invoke();
         }

--- a/Assets/NanoverImd/NanoverImd Scene.unity
+++ b/Assets/NanoverImd/NanoverImd Scene.unity
@@ -12084,6 +12084,7 @@ MonoBehaviour:
   application: {fileID: 544060994}
   nanover: {fileID: 431384315}
   defaultParent: {fileID: 1270324916}
+  calibratedParent: {fileID: 261444382}
   simulationParent: {fileID: 1270324916}
 --- !u!1 &778773330
 GameObject:

--- a/Assets/NanoverImd/NanoverImdTransformsManager.cs
+++ b/Assets/NanoverImd/NanoverImdTransformsManager.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Nanover.Core.Math;
 using Nanover.Frontend.Utility;
 using Nanover.Network.Multiplayer;
 using UnityEngine;
@@ -18,6 +19,9 @@ namespace NanoverImd
 
         [SerializeField]
         private Transform defaultParent;
+
+        [SerializeField]
+        private Transform calibratedParent;
 
         [SerializeField]
         private Transform simulationParent;
@@ -52,7 +56,12 @@ namespace NanoverImd
 
         private void Refresh()
         {
+            var m = application.CalibratedSpace.LocalToWorldMatrix;
+            calibratedParent.localPosition = m.GetPosition();
+            calibratedParent.localRotation = m.GetRotation();
+
             id2transform.Clear();
+            id2transform["calibrated"] = calibratedParent;
             id2transform["simulation"] = simulationParent;
 
             transforms.MapConfig(nanover.Multiplayer.Transforms.Values, UpdateTransformMatrix);


### PR DESCRIPTION
Reset resource values (e.g box pose) when state data is cleared by disconnect etc. Fix reseting behaviour. Offer "calibrated" space as transform primitive parent. 